### PR TITLE
fix: outdated github handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Plugin to import references from the Zotero's local database.
 
 ```lua
-use { "tiagovla/zotex.nvim", requires = "tami5/sqlite.lua" }
+use { "tiagovla/zotex.nvim", requires = "kkharji/sqlite.lua" }
 ```
 
 ## Configuration


### PR DESCRIPTION
Hello @tiagovla,

I recently changed my Github handle and realized I must keep existing references up to date, in order to prevent breaking your setup or, worse, exposing you to a security risk as a result of someone taking over my old handle and creating a repo with the same name.

Now, sqlite.lua link is updated.

